### PR TITLE
NodeManager class configuration within zenstruck_content main configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -22,12 +22,14 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('zenstruck_cms');
+        $rootNode = $treeBuilder->root('zenstruck_content');
 
         $rootNode
             ->children()
+
                 ->scalarNode('node_class')->isRequired()->end()
                 ->scalarNode('node_type_name')->defaultValue('node')->end()
+                ->scalarNode('manager_class')->defaultNull()->end()
                 ->booleanNode('use_controller')->defaultFalse()->end()
                 ->booleanNode('use_form')->defaultFalse()->end()
                 ->scalarNode('inheritance_type')->defaultValue('class_table')->end()

--- a/DependencyInjection/ZenstruckContentExtension.php
+++ b/DependencyInjection/ZenstruckContentExtension.php
@@ -42,10 +42,15 @@ class ZenstruckContentExtension extends Extension
         $content_types = array_flip($config['content_types']);
         $content_types[$config['node_class']] = 'node';
 
+
         $container->getDefinition('zenstruck_content.listener.discriminator')
                     ->replaceArgument(0, $content_types)
                     ->replaceArgument(1, $config['inheritance_type'])
                     ->replaceArgument(2, $config['discriminator_column']);
+
+        if (null !== $config['manager_class']) {
+            $container->setParameter('zenstruck_content.manager.class', $config['manager_class']);
+        }
 
         if ($config['use_controller']) {
             $loader->load('controller.xml');


### PR DESCRIPTION
There is already possibility to overwrite zenstruck_content.manager class name using parameters.ini/parameters.yml. 
I thought that it would be nice to make it possible from within zenstruck_content configuration.

I fixed as well old root configuration name.
